### PR TITLE
Replace static with const

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 use termagotchi::actions::{perform_action, Action};
 use termagotchi::state::State;
 
-static PATH: &str = "./termagotchi.json";
+const PATH: &str = "./termagotchi.json";
+
 fn main() -> Result<()> {
     // load game state
     let state = &mut State::load(PATH).unwrap();


### PR DESCRIPTION
The `static` here is not necessary and I'm sure that `const` was originally intended to be used.