### PR TITLE
Don't consume Action when possible

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,4 +1,6 @@
 use super::state::State;
+
+#[derive(Debug)]
 pub enum Action {
     Meal,
     Snack,
@@ -8,9 +10,9 @@ pub enum Action {
     Clean,
 }
 
-pub fn perform_action(action: Action, state: &mut State) {
-    match action {
-        a @ Action::Meal | a @ Action::Snack => feed(a, state),
+pub fn perform_action(action: &Action, state: &mut State) {
+    match &action {
+        Action::Meal | Action::Snack => feed(&action, state),
         Action::Play => play(state),
         Action::Clean => clean(state),
         Action::Toilet => toilet(state),
@@ -18,7 +20,7 @@ pub fn perform_action(action: Action, state: &mut State) {
     }
 }
 
-fn feed(food_type: Action, state: &mut State) {
+fn feed(food_type: &Action, state: &mut State) {
     if let Action::Meal = food_type {
         state.vitals.modify_hunger(-40);
         state.vitals.modify_comfort(-20);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,12 +40,12 @@ fn main() -> Result<()> {
             match event::read()? {
                 event::Event::Key(key_press) => match key_press.code {
                     event::KeyCode::Char('q') => break,
-                    event::KeyCode::Char('1') => perform_action(Action::Meal, state),
-                    event::KeyCode::Char('2') => perform_action(Action::Snack, state),
-                    event::KeyCode::Char('3') => perform_action(Action::Play, state),
-                    event::KeyCode::Char('4') => perform_action(Action::Scold, state),
-                    event::KeyCode::Char('t') => perform_action(Action::Toilet, state),
-                    event::KeyCode::Char('c') => perform_action(Action::Clean, state),
+                    event::KeyCode::Char('1') => perform_action(&Action::Meal, state),
+                    event::KeyCode::Char('2') => perform_action(&Action::Snack, state),
+                    event::KeyCode::Char('3') => perform_action(&Action::Play, state),
+                    event::KeyCode::Char('4') => perform_action(&Action::Scold, state),
+                    event::KeyCode::Char('t') => perform_action(&Action::Toilet, state),
+                    event::KeyCode::Char('c') => perform_action(&Action::Clean, state),
                     _ => {}
                 },
                 _ => {}


### PR DESCRIPTION
This will simplify `match` since `Action` is not consumed when possible.